### PR TITLE
Fix setting attributes when ssr

### DIFF
--- a/cjs/ssr.js
+++ b/cjs/ssr.js
@@ -14,8 +14,7 @@ const cloneNode = (current, newNode) => {
     switch (node.nodeType) {
       case 1:
         const element = new Element(node.name);
-        for (const {name, value} of node.attributes)
-          element.attributes.push({name, value});
+        element.attributes = node.attributes;
         cloneNode(node, element);
         newNode.appendChild(element);
         break;

--- a/esm/ssr.js
+++ b/esm/ssr.js
@@ -13,8 +13,7 @@ const cloneNode = (current, newNode) => {
     switch (node.nodeType) {
       case 1:
         const element = new Element(node.name);
-        for (const {name, value} of node.attributes)
-          element.attributes.push({name, value});
+        element.attributes = node.attributes;
         cloneNode(node, element);
         newNode.appendChild(element);
         break;


### PR DESCRIPTION
`element.attributes` is `EMPTY` so `push` would fail when trying to render with ssr bundle:

```html
<div><div foo="bar">Hello</div></div>
```

error message:
```
Cannot add property 0, object is not extensible
TypeError: Cannot add property 0, object is not extensible at Array.push () at cloneNode
```